### PR TITLE
add in hack to allow cythonized functions

### DIFF
--- a/discovery_sdk_utils/discovery_sdk_utils/entity_validation_funcs.py
+++ b/discovery_sdk_utils/discovery_sdk_utils/entity_validation_funcs.py
@@ -203,7 +203,7 @@ def _type_to_string(type):
 
 def _type_is_correct(item, type):
     if type == 'function':
-        return isfunction(item)
+        return isfunction(item) or hasattr(item, '__code__')
     else:
         return isinstance(item, type)
 


### PR DESCRIPTION
`isfunction` does not work for cythonized function, so I'm using the `'__code__'` attribute of functions to allow for cythonized functions to be detected in entity definitions.