### PR TITLE
use python3, python3 imports, docstring formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ Feel free to use these examples as a jumping off point in your own code.
 ### Requirements
 
 - Docker 17+ (or Discovery Binaries)
-- Python 2.7 with `pip`
+- Python 3 with `pip`
 
 ### Dependencies
 
 To ensure your dependencies install correctly, we recommend that you upgrade your `setuptools` before proceeding further.
 
 ```sh
-pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools
 ```
 
 Now you are ready to install the required dependencies with `pip`.
 This will provide you with the packages needed to run the `test_discovery.py` script, as well as the Discovery CLI.
 
 ```sh
-pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ### Obtaining credentials
@@ -73,7 +73,7 @@ Ensure that your *transcripts are unformatted text with numbers spelled out*. Fo
 
 5) Edit the credentials and other configuration parameters in `discovery_config.py`
 
-6) Run `python test_discovery.py folder_name` to test your interpreter. For example:
+6) Run `python3 test_discovery.py folder_name` to test your interpreter. For example:
 
 ```
 python test_discovery.py examples/directions
@@ -90,7 +90,7 @@ You should end up with a structure like the following for the `test_discovery.py
 
 ```
 └───greenkey-discovery-sdk
-    └───discovery_binaries_windows_10_64bit__python27_32bit
+    └───discovery_binaries_windows_10_64bit__python37_64bit
     └───examples
     └───gkcli
     │   discovery_config.py
@@ -131,7 +131,7 @@ Then, run these files through SVTServer [following our documentation](https://tr
 
 For example, you can launch a single job container with the following command for a file called `test.wav`. Be sure to set `$USERNAME` and `$SECRETKEY`
 
-```
+```bash
 docker run \
     -it \
     --rm \
@@ -140,7 +140,7 @@ docker run \
     -e GKT_USERNAME="$USERNAME" \
     -e GKT_SECRETKEY="$SECRETKEY" \
     -e TARGET_FILE="/files/test.wav" \
-    -v $(pwd):/files \
+    -v "$PWD":/files \
     -e ENABLE_CLOUD="False" \
     -e PROCS=1 \
     docker.greenkeytech.com/svtserver

--- a/discovery_sdk_utils/discovery_sdk_utils/built_in_tokens.py
+++ b/discovery_sdk_utils/discovery_sdk_utils/built_in_tokens.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 ONTOLOGICAL_TAGS = (
     'IN',

--- a/discovery_sdk_utils/discovery_sdk_utils/entity_validation_funcs.py
+++ b/discovery_sdk_utils/discovery_sdk_utils/entity_validation_funcs.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
-'''
+#!/usr/bin/env python3
+"""
 Utility functions for discovery
-'''
+"""
 from __future__ import print_function
 from inspect import isfunction
 from .built_in_tokens import BUILT_IN_TOKENS
@@ -221,8 +221,7 @@ VALIDATION_FUNCTIONS = [
 
 
 def find_errors_in_entity_definition(entity_definition, validation_functions=VALIDATION_FUNCTIONS):
-    ''' Accumulates a list of errors to return to the user.
-    '''
+    """Accumulates a list of errors to return to the user."""
     errors = []
     for func in validation_functions:
         # Minor errors are returned as strings and added to the list.

--- a/examples/directions/custom/entities/direction.py
+++ b/examples/directions/custom/entities/direction.py
@@ -1,5 +1,9 @@
 ''' This contains the entity definition for a cardinal directions '''
-from cleaning_functions import capitalize
+try:
+  from cleaning_functions import capitalize
+except ImportError:
+  from .cleaning_functions import capitalize
+
 
 DIRECTION = {
   'label': 'DIRECTION',

--- a/examples/directions/custom/entities/street_name.py
+++ b/examples/directions/custom/entities/street_name.py
@@ -2,9 +2,11 @@
 This contains the entity definition for the most popular street names in Chicago, Illinois.
 Replace these streets with whatever street names you please.
 '''
-import sys
-sys.path.append('../../nlp/')
-from cleaning_functions import capitalize
+from nlp.cleanText import text2int
+try:
+  from cleaning_functions import capitalize
+except ImportError:
+  from .cleaning_functions import capitalize
 
 STREET_NAME = {
   'label':
@@ -134,7 +136,6 @@ def format_ordinal(wordList, spacer):
   >>> format_ordinal("five three", ' ')
   '5th 3rd'
   """
-  from cleanText import text2int
 
   def add_suffix(n):
     return str(n) + 'tsnrhtdd' [n % 5 * (n % 100 ^ 15 > 4 > n % 10)::4]

--- a/examples/directions/custom/entities/street_type.py
+++ b/examples/directions/custom/entities/street_type.py
@@ -1,8 +1,10 @@
 '''
 This contains the entity definition for types of streets.
 '''
-
-from cleaning_functions import capitalize
+try:
+  from cleaning_functions import capitalize
+except ImportError:
+  from .cleaning_functions import capitalize
 
 STREET_TYPE = {
   'label':

--- a/examples/directions/send_transcript_to_discovery.sh
+++ b/examples/directions/send_transcript_to_discovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 curl -X POST http://localhost:1234/discover  \
-  -H "Content-type: multipart/form-data" \
-  -F 'data={"json_lattice": {"transcript": "I need directions to fifty five west monroe avenue by car"}};type=application/json'
+     -H "Content-Type: application/json" \
+     -d '{"transcript": "I need directions to fifty five west monroe avenue by car"}'

--- a/examples/room_dialing/send_transcript_to_discovery.sh
+++ b/examples/room_dialing/send_transcript_to_discovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 curl -X POST http://localhost:1234/discover  \
-  -H "Content-type: multipart/form-data" \
-  -F 'data={"json_lattice": {"transcript": "dial one eight"}};type=application/json'
+     -H "Content-Type: application/json" \
+     -d '{"transcript": "dial one eight"}'

--- a/examples/room_number/send_transcript_to_discovery.sh
+++ b/examples/room_number/send_transcript_to_discovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 curl -X POST http://localhost:1234/discover  \
-  -H "Content-type: multipart/form-data" \
-  -F 'data={"json_lattice": {"transcript": "five a is calling thirteen c"}};type=application/json'
+     -H "Content-Type: application/json" \
+     -d '{"transcript": "five a is calling thirteen c"}'

--- a/examples/telephone_number/send_transcript_to_discovery.sh
+++ b/examples/telephone_number/send_transcript_to_discovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 curl -X POST http://localhost:1234/discover  \
-  -H "Content-type: multipart/form-data" \
-  -F 'data={"json_lattice": {"transcript": "You can reach me at five five five four three two five nine eight one"}};type=application/json'
+     -H "Content-Type: application/json" \
+     -d '{"transcript": "You can reach me at five five five four three two five nine eight one"}'


### PR DESCRIPTION
# New Discovery version accepts json instead of form data, and uses Python3.

- Change references python to python3
- Change `$(pwd)` to "$PWD" to allow for spaces in filenames.
- Use double quotes for docstrings per PEP8.
- Start server in `Process()` for Windows compatibility with binaries.