### PR TITLE
add travis yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"  # 3.5 development branch
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+  - "3.7-dev"  # 3.7 development branch
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script:
+  - cd discovery_sdk_utils; pytest


### PR DESCRIPTION
Adds an initial travis yml file to run the existing tests to ensure there are no regressions. 
More tests can be added to make sure the other tools included in the SDK continue to work.
