### PR TITLE
Change label for room_number example

### DIFF
--- a/examples/room_number/custom/intents.json
+++ b/examples/room_number/custom/intents.json
@@ -1,7 +1,7 @@
 {
   "intents": [
     {
-      "label": "calling_room",
+      "label": "room_number",
       "entities": ["room_number"]
     }
   ]


### PR DESCRIPTION
Changing the label from "calling_room" to "room_number"
keeping the labeling consistent (like directions, telephone_number, room_dialing)

This prepares an additional 'quickstart' room_number example for the SDK docs

```
curl -X POST http://localhost:1234/process \
     -H "Content-type: application/json" \
     -d '{"intents":["room_number"], "transcript": "I am in five b"}'
```