### PR TITLE
fruit interpreter with Intents: inquiry, quote, trade, & correction 

### DIFF
--- a/discovery_config.py
+++ b/discovery_config.py
@@ -1,6 +1,6 @@
 DISCOVERY_CONFIG = {
-  "GKT_USERNAME": "username",
-  "GKT_SECRETKEY": "password",
+  "GKT_USERNAME": "gkt", #"username",
+  "GKT_SECRETKEY": "5f3d00b5b15884c280a390725a863941a68bfe55", #"password",
   "GKT_API": "https://scribeapi.greenkeytech.com/",
   "NUMBER_OF_INTENTS": "1",
   "MAX_NUMBER_OF_ENTITIES": "3",

--- a/discovery_config.py
+++ b/discovery_config.py
@@ -1,8 +1,8 @@
 DISCOVERY_CONFIG = {
-  "GKT_USERNAME": "gkt", #"username",
-  "GKT_SECRETKEY": "5f3d00b5b15884c280a390725a863941a68bfe55", #"password",
+  "GKT_USERNAME": "username",
+  "GKT_SECRETKEY": "password",
   "GKT_API": "https://scribeapi.greenkeytech.com/",
-  "NUMBER_OF_INTENTS": "1",
+  "NUMBER_OF_INTENTS": "4",
   "MAX_NUMBER_OF_ENTITIES": "3",
   "STRUCTURE_CONFIDENCE_THRESHOLD": "0.8",
   "SORT_ENTITIES_BY_LENGTH": "True"

--- a/examples/directions/tests.txt
+++ b/examples/directions/tests.txt
@@ -2,18 +2,22 @@ test: directions by car
 transcript: I need directions to fifty five west monroe avenue by car
 complete_address: 55 West Monroe Avenue
 transportation_type: car
+intent: directions
 
 test: directions by bus
 transcript: I need to get to two thirty three south wacker drive by bus
 complete_address: 233 South Wacker Drive
 transportation_type: bus
+intent: directions
 
 test: directions by train
 transcript: I'm travelling by train to two oh one east randolph street
 complete_address: 201 East Randolph Street
 transportation_type: train
+intent: directions
 
 test: directions with ordinal number
 transcript: I'm travelling by train to two oh one east fifth street
 complete_address: 201 East 5th Street
 transportation_type: train
+intent: directions

--- a/examples/fruits/custom/entities/color.py
+++ b/examples/fruits/custom/entities/color.py
@@ -1,0 +1,6 @@
+# colors and products that may be that color
+# red - apple, tomato (fruit)
+# green - tomato (vegetable)
+# orange - carrot
+# purple - carrot
+# color may be unspecified (as it is for oranges)

--- a/examples/fruits/custom/entities/price.py
+++ b/examples/fruits/custom/entities/price.py
@@ -1,0 +1,2 @@
+# price should be money/share
+# monetary string in text may be price (per share) or total cost (price * quantity)

--- a/examples/fruits/custom/entities/product.py
+++ b/examples/fruits/custom/entities/product.py
@@ -1,0 +1,5 @@
+# Products: apple (red or green), orange, tomato (fruit; red), carrot (orange or purple), tomato (vegetable; green)
+#
+# fruit interpreter page: product refers to type of fruit or vegetable
+#
+# BUT product could be defined as items with a specific fruit/vegetable name and specific color (green apple is a different product from red apple) --> motivation: price and quantity constraints operate over color + product (name) 

--- a/examples/fruits/custom/entities/product_class.py
+++ b/examples/fruits/custom/entities/product_class.py
@@ -1,0 +1,1 @@
+# Binary Category: 'fruit' or 'vegetable'

--- a/examples/fruits/custom/entities/quantity.py
+++ b/examples/fruits/custom/entities/quantity.py
@@ -1,0 +1,3 @@
+# quantity: digits (integer & decomal) or nueric term (fifty apples)
+# quantity not present for strings with intent 'inquiry'
+# order: {quantity} {color}? {product}       50 green apples / 50 apples / *green 50 apples

--- a/examples/fruits/custom/intents.json
+++ b/examples/fruits/custom/intents.json
@@ -1,0 +1,40 @@
+{
+ "intents": [
+   {
+    "label": "inquiry",
+      "domain": "food",
+      "examples": [
+        "What is your price on green apples?",
+        "How many oranges can I get for $23?",
+        "What's going on with red tomatoes today?"
+     ]
+   },
+   {
+     "label": "quotes",
+     "domain": "food",
+     "examples": [
+       "I'll buy 23 carrots for $5",
+       "Can you sell 100 green tomatoes for $50?",
+       "I can sell up to 100 oranges for $2 each"
+    ]
+   },
+   {
+     "label": "trade",
+     "domain": "food",
+     "examples": [
+       "I'll take your 100 oranges for $2 each",
+       "We're done on the 100 green tomatoes for $50",
+       "Confirming that I'll sell you 23 carrots for '$5'"
+    ]
+   },
+   {
+     "label": "correction",
+     "domain": "food",
+     "examples": [
+       "Scratch that, I can sell 90 oranges for $2 each",
+       "Correction, my price on 23 carrots is $6",
+       "I need to revise my offer. I'll give you $40 for 60 oranges"
+    ]
+  }
+ ]
+}

--- a/examples/fruits/custom/intents.json
+++ b/examples/fruits/custom/intents.json
@@ -10,10 +10,10 @@
      ]
    },
    {
-     "label": "quotes",
+     "label": "quote",
      "domain": "food",
      "examples": [
-       "I'll buy 23 carrots for $5",
+       "I will buy 23 carrots for $5",
        "Can you sell 100 green tomatoes for $50?",
        "I can sell up to 100 oranges for $2 each"
     ]

--- a/examples/fruits/custom/intents_ner.json
+++ b/examples/fruits/custom/intents_ner.json
@@ -1,0 +1,40 @@
+{
+ "intents": [
+  {
+    "label": "inquiry",
+    "domain": "food",
+    "examples": [
+      "What is your price on {color} {fruit}?",
+      "How many {fruit} can I get for {money}?",
+      "What's going on with {color} {fruit} today?"
+     ]
+   },
+   {
+     "label": "quotes",
+     "domain": "food",
+     "examples": [
+       "I'll buy {quantity} {vegetable} for {money}" ,
+       "Can you sell {quantity} {color} {fruit} for {money}?",
+       "I can sell up to {quantity} {fruit} for {money} each"
+     ]
+   },
+   {
+     "label": "trade",
+     "domain": "food",
+     "examples": [
+       "I'll take your {quantity} {fruit} for {money} each",
+       "We're done on the {quantity} {color} {fruit} for {money}",
+       "Confirming that I'll sell you {quantity} {vegetable} for {money}"
+     ]
+   },
+   {
+     "label": "correction",
+     "domain": "food",
+     "examples": [
+       "Scratch that, I can sell {quantity} {fruit} for {money} each",
+       "Correction, my price on {quantity} {vegetable} is {money}",
+       "I need to revise my offer. I'll give you {money} for {quantity} {fruit}"
+     ]
+   }
+ ]
+}

--- a/examples/fruits/readme.txt
+++ b/examples/fruits/readme.txt
@@ -1,0 +1,8 @@
+"""
+ Interpreter that categorizes text as Inquiry, Quote, Trade or Correction
+ Asset class: Food
+ Product classes: Fruits, Vegetab;es
+"""
+#
+# filepath: greenkey-discovery-sdk/exmples/fruits/custom/intents.json
+# schema.json -> in custom/ directory (optional); output format

--- a/examples/fruits/send_transcript_to_discovery.sh
+++ b/examples/fruits/send_transcript_to_discovery.sh
@@ -1,9 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-PORT=1234
-
-TRANSCRIPT="I'll buy 70 purple carrots for \$10 each"
-
-curl -X POST http://localhost:$PORT/discover  \
+curl -X POST http://localhost:1234/discover  \
      -H "Content-Type: application/json" \
-     -d '{"transcript": $TRANSCRIPT}'
+     -d '{"transcript": "I will buy 70 purple carrots for $10 each"}'

--- a/examples/fruits/send_transcript_to_discovery.sh
+++ b/examples/fruits/send_transcript_to_discovery.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+PORT=1234
+
+TRANSCRIPT="I'll buy 70 purple carrots for \$10 each"
+
+curl -X POST http://localhost:$PORT/discover  \
+     -H "Content-Type: application/json" \
+     -d '{"transcript": $TRANSCRIPT}'

--- a/examples/fruits/tests.txt
+++ b/examples/fruits/tests.txt
@@ -1,0 +1,14 @@
+test: (1) Inquiry
+transcript: What is your price on green tomatoes?
+intent: inquiry
+
+test: (2) Quote (bid)
+transcript: I'll buy 70 purple carrots for $10 each
+intent: quote
+
+test: (3) Trade
+transcript: Confirming I'll sell you 20 oranges for $20
+intent: trade
+
+test: (4) Correction
+transcript: I have to change my offer. I'll buy 50 red apples for $100

--- a/examples/fruits/tests_ner.txt
+++ b/examples/fruits/tests_ner.txt
@@ -1,0 +1,32 @@
+test: (1) Inquiry
+transcript: What is your price on green tomatoes?
+intent: inquiry
+product_class: vegetable
+product: tomato
+color: green
+
+test: (2) Quote
+transcript: I'll buy 70 purple carrots for $10 each
+intent: quote
+product_class: vegetable
+product: carrot
+color: purple
+price: 10
+quantity: 100
+
+test: (3) Trade
+transcript: Confirming I'll sell you 20 oranges for $20
+intent: trade
+product_class: fruit
+product: orange
+color:
+price: 20
+quantity: 20
+
+test: (4) Correction
+transcript: I have to change my offer. I'll buy 50 red apples for $100
+intent: correction
+product_class: fruit
+product: apple
+color: red
+price: 100

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -160,21 +160,20 @@ def test_single_entity(entities, test_name, test_value):
     return (0, 0)
 
 
-def test_single_case(test):
+def test_single_case(test, intent):
     """
     Run a single test case
     Return the number of errors
     """
-    print("======\nTesting: {}".format(test['test']))
-    resp = submit_transcript(test['transcript'])
+    #print("======\nTesting: {}".format(test['test']))
+    #resp = submit_transcript(test['transcript'])
 
     # Check if a valid response was received
-    if not is_valid_response(resp):
-        fail_test(resp)
+    #if not is_valid_response(resp):
+    #    fail_test(resp)
 
     # For now, only keep the first intent:
-    intent = resp["intents"][0]
-
+    #intent = resp["intents"][0]
     # Get all values of entities
     entities = {x["label"]: x["matches"][0][0]["value"] for x in intent["entities"]}
 
@@ -219,7 +218,26 @@ def test_all(test_file):
     total_characters = 0
 
     for test in tests:
-        (failure, errors, char_errors, characters) = test_single_case(test)
+        print("======\nTesting: {}".format(test['test']))
+        resp = submit_transcript(test['transcript'])
+
+        # Check if a valid response was received
+        if not is_valid_response(resp):
+            fail_test(resp)
+
+        # For now, only keep the first intent:
+        most_likely_intent = resp["intents"][0]
+
+        if 'intent' in test and test['intent'] != most_likely_intent['label']:
+           #print("foo")
+          #if test['intent'] != most_likely_intent["label"]:
+            print("bad intent")
+            failed_tests += 1
+            fail_test(resp, message="Observed intent does not match expected intent!", continued=True)
+            continue
+
+        # check entities if 'intent' not present in test or it is present and correect
+        (failure, errors, char_errors, characters) = test_single_case(test, most_likely_intent)
         failed_tests += failure
         total_errors += errors
         total_char_errors += char_errors

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -183,7 +183,7 @@ def test_single_case(test, intent):
 
     # Loop through all entity tests
     for test_name, test_value in test.items():
-        if test_name in ['test', 'transcript']:
+        if test_name in ['test', 'transcript', 'intent']:
             continue
 
         (errors, char_errors) = test_single_entity(entities, test_name, test_value)
@@ -221,12 +221,18 @@ def test_all(test_file):
         print("======\nTesting: {}".format(test['test']))
         resp = submit_transcript(test['transcript'])
 
+        #print("Response from Discovery: {}".format(resp))
+
         # Check if a valid response was received
         if not is_valid_response(resp):
             fail_test(resp)
 
         # For now, only keep the first intent:
         most_likely_intent = resp["intents"][0]
+
+        if 'intent' in test:
+            print("Expected Intent: {}".format(test['intent']))
+            print("Observed Intent: {}".format(most_likely_intent['label']))
 
         if 'intent' in test and test['intent'] != most_likely_intent['label']:
            #print("foo")

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -212,6 +212,13 @@ def test_single_case(test_dict, response_intent_dict):
 def test_all(test_file):
     """
     Runs all defined tests
+    
+    :param test_file: str, path to file with test(s) (tests.txt)
+
+    :return: 
+       for each test, posts transcript to Discovery and compares value(s) of
+         intent and/or entity(ies) in response to expected value(s) in test file
+      prints outcomes to stdout: # of passing tests, character error rate for entities
     """
     tests = load_tests(test_file)
 
@@ -224,26 +231,19 @@ def test_all(test_file):
     total_characters = 0
 
     for test in tests:
-        print("======\nTesting: {}".format(test['test']))
+        print("======\nTest Name: {}".format(test['test']))
         resp = submit_transcript(test['transcript'])
-
-        #print("Response from Discovery: {}".format(resp))
 
         # Check if a valid response was received
         if not is_valid_response(resp):
             fail_test(resp)
 
-        # For now, only keep the first intent:
+        # keep only the most likely hypothesis from Discovery:
         most_likely_intent = resp["intents"][0]
 
         if 'intent' in test:
-            print("Expected Intent: {}".format(test['intent']))
-            print("Observed Intent: {}".format(most_likely_intent['label']))
-
+            print("\n Expected Intent: {} \n Observed Intent: {}\n".format(test['intent'], most_likely_intent['label']))
         if 'intent' in test and test['intent'] != most_likely_intent['label']:
-           #print("foo")
-          #if test['intent'] != most_likely_intent["label"]:
-            print("bad intent")
             failed_tests += 1
             fail_test(resp, message="Observed intent does not match expected intent!", continued=True)
             continue


### PR DESCRIPTION
(1) intents.json defines 4 intents (inquiry, quote, trade, correction) with example sentences and `tests.txt` contains tests for intent only
(2) complementary files with named entities in place of respective strings in text: `intents_ner.json` and `tests_ner.txt`
(3) entities: product_class, product, color, quantity, price  (specified in fruit interpreter confluence page); python file for each with notes in entities directory; definitions to be added

(note: entities included are not intended to be a comprehensive or determinate; rules operate over combinations of entities)