### PR TITLE
set `docker run` argument of `--name` as variable in `discovery_config.py`

### DIFF
--- a/discovery_config.py
+++ b/discovery_config.py
@@ -9,7 +9,7 @@ DISCOVERY_CONFIG = {
   "PORT": "1234",  # Port that Discovery will bind to on the Docker daemon, change if port is taken already
 }
 
-DOCKER_NAME = 'discovery-dev'
+DOCKER_NAME = "discovery-dev"
 DISCOVERY_PORT = "1234"  # This is the port you will POST to, e.g. curl localhost:1234
 DISCOVERY_SHUTDOWN_SECRET = "greenkeytech"
 DISCOVERY_HOST = "localhost"

--- a/discovery_config.py
+++ b/discovery_config.py
@@ -9,6 +9,7 @@ DISCOVERY_CONFIG = {
   "PORT": "1234",  # Port that Discovery will bind to on the Docker daemon, change if port is taken already
 }
 
+DOCKER_NAME = 'discovery-dev'
 DISCOVERY_PORT = "1234"  # This is the port you will POST to, e.g. curl localhost:1234
 DISCOVERY_SHUTDOWN_SECRET = "greenkeytech"
 DISCOVERY_HOST = "localhost"

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -77,7 +77,6 @@ def wait_for_discovery_launch():
         exit(1)
 
 
-
 def shutdown_discovery():
     """
     Shuts down the Discovery engine Docker container
@@ -100,7 +99,6 @@ def load_tests(test_file_argument):
     Loads and parses the test file
     """
     test_file = [x.rstrip() for x in open(test_file_argument)]
-
     tests = []
     current_test = {}
     for line in test_file:
@@ -112,10 +110,8 @@ def load_tests(test_file_argument):
             current_test = {key: value}
         elif len(key) > 0:
             current_test[key] = value
-
     if len(current_test.keys()) > 0:
         tests.append(current_test)
-
     return tests
 
 
@@ -306,8 +302,6 @@ def fail_test(resp, message="", continued=False):
 
     if not continued:
         docker_log_and_stop()
-        # subprocess.call("docker logs {docker_name}", shell=True)
-        # subprocess.call("docker stop {docker_name}", shell=True)
         exit(1)
 
 

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -23,11 +23,24 @@ import editdistance
 from importlib import import_module
 from discovery_sdk_utils import find_errors_in_entity_definition
 from discovery_config import DISCOVERY_PORT, DISCOVERY_HOST, DISCOVERY_SHUTDOWN_SECRET
+from discovery_config import DOCKER_NAME
 from launch_discovery import launch_discovery
 
 """
 Functions for handling the Discovery Docker container
 """
+
+#TODO Remap the following Bash codes; confusing as opposite of standard Python codes
+BAD_EXIT_CODE = 1
+GOOD_EXIT_CODE = 0
+
+# DOCKER_NAME = 'discovery-dev'
+
+
+def docker_log_and_stop(docker_name):
+    """name assigned to Docker container"""
+    subprocess.call(f"docker logs {docker_name}", shell=True)
+    subprocess.call(f"docker stop {docker_name}", shell=True)
 
 
 def check_discovery_status():
@@ -35,10 +48,8 @@ def check_discovery_status():
     Checks whether Discovery is ready to receive new jobs
     """
     r = requests.get("http://{}:{}/status".format(DISCOVERY_HOST, DISCOVERY_PORT))
-
     if 'listening' in json.loads(r.text)['message']:
         return True
-
     return False
 
 
@@ -52,7 +63,6 @@ def wait_for_discovery_status(timeout=1, retries=5):
             return True
         except Exception:
             time.sleep(timeout)
-
     return False
 
 
@@ -60,13 +70,12 @@ def wait_for_discovery_launch():
     """
     Wait for launch to complete
     """
-
     # Timeout of 25 seconds for launch
     if not wait_for_discovery_status(timeout=5, retries=5):
         print("Couldn't launch Discovery, printing Docker logs:\n---\n")
-        subprocess.call("docker logs discovery-dev", shell=True)
-        subprocess.call("docker stop discovery-dev", shell=True)
+        docker_log_and_stop(DOCKER_NAME)
         exit(1)
+
 
 
 def shutdown_discovery():
@@ -296,8 +305,9 @@ def fail_test(resp, message="", continued=False):
     print("{}\n---\n".format(resp))
 
     if not continued:
-        subprocess.call("docker logs discovery-dev", shell=True)
-        subprocess.call("docker stop discovery-dev", shell=True)
+        docker_log_and_stop(DOCKER_NAME)
+        # subprocess.call("docker logs {docker_name}", shell=True)
+        # subprocess.call("docker stop {docker_name}", shell=True)
         exit(1)
 
 

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -37,10 +37,10 @@ GOOD_EXIT_CODE = 0
 # DOCKER_NAME = 'discovery-dev'
 
 
-def docker_log_and_stop(docker_name):
+def docker_log_and_stop():
     """name assigned to Docker container"""
-    subprocess.call(f"docker logs {docker_name}", shell=True)
-    subprocess.call(f"docker stop {docker_name}", shell=True)
+    subprocess.call(f"docker logs {}".format(DOCKER_NAME), shell=True)
+    subprocess.call(f"docker stop {}".format(DOCKER_NAME), shell=True)
 
 
 def check_discovery_status():
@@ -73,7 +73,7 @@ def wait_for_discovery_launch():
     # Timeout of 25 seconds for launch
     if not wait_for_discovery_status(timeout=5, retries=5):
         print("Couldn't launch Discovery, printing Docker logs:\n---\n")
-        docker_log_and_stop(DOCKER_NAME)
+        docker_log_and_stop()
         exit(1)
 
 
@@ -305,7 +305,7 @@ def fail_test(resp, message="", continued=False):
     print("{}\n---\n".format(resp))
 
     if not continued:
-        docker_log_and_stop(DOCKER_NAME)
+        docker_log_and_stop()
         # subprocess.call("docker logs {docker_name}", shell=True)
         # subprocess.call("docker stop {docker_name}", shell=True)
         exit(1)

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -39,8 +39,8 @@ GOOD_EXIT_CODE = 0
 
 def docker_log_and_stop():
     """name assigned to Docker container"""
-    subprocess.call(f"docker logs {}".format(DOCKER_NAME), shell=True)
-    subprocess.call(f"docker stop {}".format(DOCKER_NAME), shell=True)
+    subprocess.call("docker logs {}".format(DOCKER_NAME), shell=True)
+    subprocess.call("docker stop {}".format(DOCKER_NAME), shell=True)
 
 
 def check_discovery_status():


### PR DESCRIPTION
(1) This modification was made in order to account for docker log and stop functions that specifically relied on the hardcoded default `discovery-dev` name. 
(2) This also enables users to easily specify `--name` 

--------------------------------------------------------------
- variable DOCKER_NAME added. default value `discovery-dev`
   - default value was previously  hardcoded into `launch_discovery.py` and
 `test_discovery.py`

(2) `launch_discovery.py`
- DOCKER_NAME imported along with DISCOVERY_PORT and DISCOVERY_CONFIG
from `discovery_config.py`

- add `discovery_name` to arguments of in private function `_launch_container` and swap hardcoded value of `discovery-dev` for docker param `--name` (see `launch command`: docker run + relevant args)

(3) `test_discovery.py`
- functions `wait_for_discovery_launch` and `fail_test` were btoh
calling shell commands `docker log discovery-dev` and docker stop
discovery-dev`
- that suggests that these commands would not work if conditions under
certain circumstances; Note: requires further testing

- for modularity, both `docker logs DOCKER_NAME` and `docker stop
DOCKER_NAME` have been encapsulated in helper function
`docker_log_and_stop` and calling functions use value of DOCKER_NAME
from config file.

- ** important to update DOCKER_NAME if it is already in use;
recommended to select unique name regaredless

  - IMPORTANT: