### PR TITLE
Reduce output of exceptions that occur while Discovery is starting

### DIFF
--- a/test_discovery.py
+++ b/test_discovery.py
@@ -83,7 +83,7 @@ def wait_for_discovery_status():
             check_discovery_status()
             return True
         except Exception:
-            logger.error("Could not reach discovery, attempt {0} of {1}".format(i, RETRIES))
+            logger.error("Could not reach discovery, attempt {0} of {1}".format(i+1, RETRIES))
             time.sleep(TIMEOUT)
     return False
 

--- a/test_discovery.py
+++ b/test_discovery.py
@@ -83,7 +83,7 @@ def wait_for_discovery_status():
             check_discovery_status()
             return True
         except Exception:
-            logger.exception("Error: Exception during status check", exc_info=True)
+            logger.error("Could not reach discovery, attempt {0} of {1}".format(i, RETRIES))
             time.sleep(TIMEOUT)
     return False
 


### PR DESCRIPTION
The connection errors while Discovery is starting are very verbose and will nearly always occur once since Discovery can take a minute to start up. This PR reduces that verbosity to print a more friendly error for the user.